### PR TITLE
NextWP Starter: remove product from postTypes in nextWpStaticParams

### DIFF
--- a/apps/next-wordpress-starter/src/app/[[...paths]]/page.tsx
+++ b/apps/next-wordpress-starter/src/app/[[...paths]]/page.tsx
@@ -22,6 +22,6 @@ export { generateMetadata } from "@nextwp/core";
 
 export async function generateStaticParams() {
   return nextWpStaticParams({
-    postTypes: ["pages", "posts", "product"],
+    postTypes: ["pages", "posts"],
   });
 }


### PR DESCRIPTION
**Issue:**
When you run `create-nextwp-app`, add correct .env variables, and run `npm run dev`, you will get an error:

```
Error: Invalid post type "product". Available post types are: posts, pages, media, menu-items, blocks, templates, template-parts, navigation
```

This PR removes "product" from postsTypes in nextWpStaticParams.

This will allow devs to immediately run "npm run dev" as soon as they set .env variables and see their site with no errors.