### PR TITLE
Docs: Misc Fixes

### DIFF
--- a/apps/docs/src/app/faq/why-rest-api/page.mdx
+++ b/apps/docs/src/app/faq/why-rest-api/page.mdx
@@ -47,7 +47,7 @@ NextWP leverages the WP REST API for a more efficient development workflow, part
 - **Simplified Data Retrieval**: Fetching data via the WP REST API is generally more straightforward, especially for custom fields or blocks, enabling faster prototyping and development cycles.
 - **User-Friendly for Developers**: The REST API's approach, combined with NextWP's type support, offers a gentler learning curve, accelerating onboarding and productivity.
 
-## TypeScript
+## Conclusion
 
 In essence, NextWP’s integration with the WP REST API not only makes the development process smoother but also enriches the overall developer experience, allowing teams to focus on feature development with less concern about data fetching complexities.
 

--- a/apps/docs/src/app/packages/nextwp/core/components/page.mdx
+++ b/apps/docs/src/app/packages/nextwp/core/components/page.mdx
@@ -1,3 +1,5 @@
+import { CodeGroup } from '@/components/Code'
+
 export const metadata = {
   title: 'Components',
   description: '',
@@ -11,8 +13,8 @@ A collection of components for use in NextWP projects. {{ className:"lead"}}
 
 A component used in a Next.js dynamic route to render Wordpress pages and posts.
 
-<CodeGroup>
-```javascript {{title:"src/app/[[...paths]]/page.tsx"}}
+<CodeGroup title={"src/app/[[...paths]]/page.tsx"}>
+```javascript
 import { WordpressTemplate, type RouteParams, type SearchParams } from "@nextwp/core";
 import templates from "@/templates";
 
@@ -231,9 +233,9 @@ The icon uploaded in WordPress will be used as the favicon and app icon.
 
 ### Usage
 
-<CodeGroup>
+<CodeGroup title={"src/app/icon.tsx"}>
 
-```tsx {{ title: 'src/app/icon.tsx' }}
+```tsx
 export { Icon as default } from '@nextwp/core'
 
 export const runtime = 'edge'
@@ -269,9 +271,9 @@ The icon uploaded in WordPress will be used as the favicon and app icon.
 
 ### Usage
 
-<CodeGroup>
+<CodeGroup title={"src/app/apple-icon.tsx"}>
 
-```tsx {{ title: 'src/app/apple-icon.tsx' }}
+```tsx
 export { AppleIcon as default } from '@nextwp/core'
 
 export const runtime = 'edge'

--- a/apps/docs/src/app/packages/nextwp/core/functions/page.mdx
+++ b/apps/docs/src/app/packages/nextwp/core/functions/page.mdx
@@ -9,8 +9,6 @@ The REST API functions are a set of functions that can be used to retrieve data 
 
 <Note>This is a work in progress. The functions are not yet documented.</Note>
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam euismod, nisl eget ultricies aliquam, nunc nisl aliquet nunc, quis aliqu
-
 ## getMenuItems {{ tag: 'GET', label: '/wp-json/wp/v2/menus?slug={slug}' }}
 
 <Row>
@@ -167,7 +165,8 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam euismod, nisl eg
       url?: string;
       posts_per_page?: number;
       page_on_front?: number;
-      page_for_posts?: number;      site_logo?: number;
+      page_for_posts?: number;
+      site_logo?: number;
       site_icon?: number;
       email?: string;
       timezone?: string;


### PR DESCRIPTION
This PR will 
- add missing titles to CodeGroups in Components docs
- remove the Lorem text in the one FAQ
- change the TypeScript heading in the one FAQ to Conclusion
- fix the typo in the Return type for getSiteSettings