### PR TITLE
Docs: fix typos and add NEXT_SITE_URL to env variables

### DIFF
--- a/apps/docs/src/app/environment-variables/page.mdx
+++ b/apps/docs/src/app/environment-variables/page.mdx
@@ -29,6 +29,10 @@ You can quickly copy these randomly generated example variables to your `.env.lo
 ## Environment Variables {{ anchor: false}}
 
 <Properties>
+  <Property name="NEXT_SITE_URL" type="string">
+    The URL of your frontend site. <br />
+    Example: `https://example.com`
+  </Property>
   <Property name="NEXT_PUBLIC_WP_URL" type="string">
     The URL of your WordPress site used to fetch the WP REST API. <br />
     Example: `https://example-wordpress.com`

--- a/apps/docs/src/app/packages/nextwp/core/components/page.mdx
+++ b/apps/docs/src/app/packages/nextwp/core/components/page.mdx
@@ -73,7 +73,7 @@ const templates = {
     special: SpecialPostTemplate,
   },
   archive:{
-    post: PostArchiveTemplate,
+    posts: PostArchiveTemplate,
     // custom post type archive
     movie: MovieArchiveTemplate,
   },

--- a/apps/docs/src/components/env-code-block.tsx
+++ b/apps/docs/src/components/env-code-block.tsx
@@ -4,7 +4,8 @@ import { Code, CodeGroup, CodeButton } from '@/components/Code'
 import { useEffect, useState } from 'react'
 
 export function EnvCodeBlock() {
-  const [code, setCode] = useState(`NEXT_PUBLIC_WP_URL=
+  const [code, setCode] = useState(`NEXT_SITE_URL=
+NEXT_PUBLIC_WP_URL=
 WP_APPLICATION_PASSWORD=
 NEXT_PREVIEW_SECRET=
 REVALIDATE_SECRET_KEY=`)
@@ -22,7 +23,8 @@ REVALIDATE_SECRET_KEY=`)
       .map(() => chars[Math.floor(Math.random() * chars.length)])
       .join('')
 
-    setCode(`NEXT_PUBLIC_WP_URL=
+    setCode(`NEXT_SITE_URL=
+NEXT_PUBLIC_WP_URL=
 WP_APPLICATION_PASSWORD=
 NEXT_PREVIEW_SECRET={#string}${NEXT_PREVIEW_SECRET}{#}
 REVALIDATE_SECRET_KEY={#string}${REVALIDATE_SECRET_KEY}{#}`)
@@ -40,7 +42,8 @@ REVALIDATE_SECRET_KEY={#string}${REVALIDATE_SECRET_KEY}{#}`)
           <>
             <CodeButton
               onClick={() =>
-                setCode(`NEXT_PUBLIC_WP_URL=
+                setCode(`NEXT_SITE_URL=
+NEXT_PUBLIC_WP_URL=
 WP_APPLICATION_PASSWORD=
 NEXT_PREVIEW_SECRET=
 REVALIDATE_SECRET_KEY=`)


### PR DESCRIPTION
This PR will
- Fix the typo in the `WordPressTemplate` templates example, from `archive: { post: ... } }` to `archive: { posts: ... } }`.
- add NEXT_SITE_URL to Environment Variables docs.

**Issue:** 

Without the NEXT_SITE_URL, if devs have followed the docs for adding `@nextwp/core` to their project they will receive the following error:

```
 ⨯ Internal error: Error: No NEXT_SITE_URL provided. Please set NEXT_SITE_URL env
```

<img width="952" alt="Screen Shot 2024-02-12 at 6 36 37 PM" src="https://github.com/CalebBarnes/nextwp/assets/50815816/9ba89bb4-9078-406f-b115-8eaaf25aea3b">