### PR TITLE
create-nextwp-app defaulting to "create-nextwp-app"

### DIFF
--- a/packages/create-nextwp-app/bin/create-nextwp-app.js
+++ b/packages/create-nextwp-app/bin/create-nextwp-app.js
@@ -12,15 +12,18 @@ child.on("exit", process.exit);
 
 function getExecutable() {
   const osPlatform = process.platform;
-  let executable = "create-nextwp-app";
 
+  let executable = "create-nextwp-app";
   switch (osPlatform) {
     case "win32":
       executable = "create-nextwp-app.exe";
+      break;
     case "darwin":
       executable = "create-nextwp-app";
+      break;
     case "linux":
       executable = "create-nextwp-app-linux";
+      break;
     default:
       executable = "create-nextwp-app";
   }


### PR DESCRIPTION
#55 
The execution falls through to the next case, eventually reaching the default case, which sets the executable variable to "create-nextwp-app" regardless of the actual platform.


Added breaks to hopefully solve this issue