### PR TITLE
Toolkit/acf menu items fix

### DIFF
--- a/wordpress/plugins/nextwp-toolkit/endpoints/menu-items-add-acf.php
+++ b/wordpress/plugins/nextwp-toolkit/endpoints/menu-items-add-acf.php
@@ -1,22 +1,30 @@
 <?php
+
 /**
  * Add ACF fields to menu items in the REST API
- * For some reason, this was not included in the ACF plugin
  */
-add_filter("rest_pre_echo_response", function($result, $server, $request){
-    $route = $request->get_route();
-  
-    if ($route == "/wp/v2/menu-items") {
-      $result = array_map(function($item){
-        $fields = get_fields($item["id"]);
-        if ($fields){
-          $item['acf'] = $fields;
-        }
-        return $item;
-      }, $result);
-    }
-  
-    return $result;
-  }, 10, 3);
+add_filter("rest_pre_echo_response", function ($result, $server, $request) {
+  $route = $request->get_route();
 
-?>
+  if ($route == "/wp/v2/menu-items") {
+    if (isset($result["code"])) { // example: "code": "rest_cannot_view"
+      return $result;
+    }
+    if (!class_exists('ACF')) { // ACF is not installed
+      return $result;
+    }
+
+    $result = array_map(function ($item) {
+      if (!isset($item["id"])) {
+        return $item;
+      }
+      $fields = get_fields($item["id"]);
+      if ($fields) {
+        $item['acf'] = $fields;
+      }
+      return $item;
+    }, $result);
+  }
+
+  return $result;
+}, 10, 3);

--- a/wordpress/plugins/nextwp-toolkit/nextwp-toolkit.php
+++ b/wordpress/plugins/nextwp-toolkit/nextwp-toolkit.php
@@ -3,7 +3,7 @@
 * Plugin Name: NextWP - Headless Toolkit
 * Plugin URI: https://www.nextwp.org/packages/wordpress/nextwp-toolkit-plugin
 * Description: A toolkit for headless Wordpress sites built with NextWP
-* Version: 1.1.5
+* Version: 1.1.6
 * Author: Caleb Barnes
 * Author URI: https://github.com/CalebBarnes
 */


### PR DESCRIPTION
only attempt to process acf fields on menu items if acf installed and user has permissions to view menu items

fixes: https://github.com/CalebBarnes/nextwp/issues/59